### PR TITLE
bump for release `v0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "doppelganger-wrapper"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doppelganger-wrapper"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
This version use doppelganger __only__ for _bite_