### PR TITLE
Bump to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-hub-rococo-runtime"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "assets-common",
  "bp-asset-hub-rococo",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "asset-hub-westend-runtime"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "assets-common",
  "bp-asset-hub-rococo",
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "asset-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -1472,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1778,7 +1778,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hash-db",
  "log",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "bp-asset-hub-rococo"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "bp-asset-hub-westend"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-cumulus"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-rococo"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-westend"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-bulletin"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2236,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "bp-rococo"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "bp-westend"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2352,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-rococo-runtime"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-asset-hub-rococo",
  "bp-asset-hub-westend",
@@ -2472,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-westend-runtime"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-asset-hub-rococo",
  "bp-asset-hub-westend",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "collectives-westend-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -3306,7 +3306,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "coretime-westend-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3916,7 +3916,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-proof-size-recording"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -3968,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -4075,7 +4075,7 @@ dependencies = [
  "sp-api",
  "sp-consensus-babe",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-externalities",
  "sp-inherents",
  "sp-io",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4165,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "approx",
  "bitflags 1.3.2",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "doppelganger"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "asset-hub-rococo-runtime",
  "asset-hub-westend-runtime",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "doppelganger-consensus"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4987,9 +4987,11 @@ dependencies = [
  "serde_json",
  "sp-authority-discovery",
  "sp-core",
+ "sp-crypto-ec-utils",
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
+ "sp-statement-store",
  "sp-storage",
  "sp-trie",
  "tokio",
@@ -4997,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "doppelganger-wrapper"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "color-eyre",
@@ -5168,7 +5170,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "emulated-integration-tests-common"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -5360,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
 ]
@@ -5625,7 +5627,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5661,7 +5663,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "anyhow",
  "frame-support",
@@ -5686,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -5755,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5785,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5796,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5813,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5843,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -5859,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "indicatif",
@@ -5869,7 +5871,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
@@ -5881,7 +5883,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5895,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -5937,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5950,14 +5952,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -5969,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5979,7 +5981,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5998,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6012,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -6022,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6222,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -6399,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "glutton-westend-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -8747,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "log",
@@ -8766,7 +8768,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9395,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "pallet-accumulate-and-forward"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9409,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "pallet-ah-ops"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9430,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9441,7 +9443,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-io",
  "sp-runtime",
 ]
@@ -9449,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9467,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9485,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-precompiles"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9500,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9515,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9529,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9547,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9563,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9579,7 +9581,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9591,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9606,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-precompiles"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "const-crypto",
  "ethereum-standards",
@@ -9628,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9638,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9654,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9669,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9682,7 +9684,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9705,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9726,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9742,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9761,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -9786,7 +9788,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9803,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9822,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9841,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9861,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9884,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9902,7 +9904,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9920,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-session-benchmarking",
  "frame-benchmarking",
@@ -9940,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9957,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9971,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10001,7 +10003,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10032,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10042,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10053,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10069,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10087,7 +10089,7 @@ dependencies = [
 [[package]]
 name = "pallet-dap"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10104,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10119,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10136,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "pallet-derivatives"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10156,7 +10158,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10171,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10189,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10210,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10231,7 +10233,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10244,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10262,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10280,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10298,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10320,7 +10322,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10336,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10355,7 +10357,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10370,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10381,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10394,7 +10396,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10410,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10430,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10448,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10467,7 +10469,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10481,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10493,7 +10495,7 @@ dependencies = [
 [[package]]
 name = "pallet-multi-asset-bounties"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10510,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10521,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10534,7 +10536,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10551,7 +10553,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10560,7 +10562,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10570,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10581,7 +10583,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10599,7 +10601,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10619,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10629,7 +10631,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10644,7 +10646,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10668,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "pallet-oracle"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10686,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "pallet-oracle-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10697,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10715,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10727,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10744,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10762,7 +10764,7 @@ dependencies = [
 [[package]]
 name = "pallet-pgas-allowance"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10777,7 +10779,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10793,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10803,7 +10805,7 @@ dependencies = [
 [[package]]
 name = "pallet-psm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10817,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10835,7 +10837,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10848,7 +10850,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10865,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10881,7 +10883,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -10932,7 +10934,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "anyhow",
@@ -10949,7 +10951,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10959,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "bitflags 1.3.2",
@@ -10974,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10990,7 +10992,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11003,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -11017,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -11029,7 +11031,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11046,7 +11048,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11059,7 +11061,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11081,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11097,7 +11099,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11109,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11126,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11147,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11172,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11192,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11212,7 +11214,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11222,7 +11224,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11231,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11241,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11258,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11275,7 +11277,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11290,7 +11292,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11308,7 +11310,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11326,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11342,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11358,7 +11360,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11370,7 +11372,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11389,7 +11391,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11400,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11414,7 +11416,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11429,7 +11431,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11444,7 +11446,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11458,7 +11460,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting-precompiles"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "frame-benchmarking",
@@ -11478,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11488,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",
@@ -11512,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11529,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11551,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11571,7 +11573,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-precompiles"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "pallet-revive",
@@ -11585,7 +11587,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11618,7 +11620,7 @@ dependencies = [
 [[package]]
 name = "parachains-common-types"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-consensus-aura",
  "sp-core",
@@ -11628,7 +11630,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -11822,7 +11824,7 @@ dependencies = [
 [[package]]
 name = "penpal-runtime"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",
@@ -11892,7 +11894,7 @@ dependencies = [
 [[package]]
 name = "people-westend-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -12154,7 +12156,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12172,7 +12174,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12187,7 +12189,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fatality",
  "futures",
@@ -12210,7 +12212,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12243,7 +12245,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12261,14 +12263,14 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "substrate-build-script-utils 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "substrate-build-script-utils 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12297,7 +12299,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12308,7 +12310,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fatality",
  "futures",
@@ -12330,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12344,7 +12346,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12357,7 +12359,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -12365,7 +12367,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12388,7 +12390,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12406,7 +12408,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12438,7 +12440,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -12462,7 +12464,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "futures",
@@ -12481,7 +12483,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12502,7 +12504,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12517,7 +12519,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -12541,7 +12543,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12555,7 +12557,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12571,7 +12573,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fatality",
  "futures",
@@ -12589,7 +12591,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -12606,7 +12608,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fatality",
  "futures",
@@ -12621,7 +12623,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12640,7 +12642,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -12668,7 +12670,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12681,7 +12683,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12698,7 +12700,7 @@ dependencies = [
  "seccompiler",
  "sp-core",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -12709,7 +12711,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-execute-worker"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -12727,7 +12729,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-prepare-worker"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -12745,7 +12747,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12760,7 +12762,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bs58",
  "futures",
@@ -12777,7 +12779,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12802,7 +12804,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12826,7 +12828,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12835,7 +12837,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12863,7 +12865,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fatality",
  "futures",
@@ -12893,7 +12895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -12983,7 +12985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -13003,7 +13005,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "bounded-collections 0.3.2",
@@ -13020,7 +13022,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "bounded-collections 0.3.2",
@@ -13049,7 +13051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13064,7 +13066,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -13097,7 +13099,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -13146,7 +13148,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -13158,7 +13160,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -13206,7 +13208,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -13528,7 +13530,7 @@ dependencies = [
  "sp-core-hashing",
  "sp-core-hashing-proc-macro",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-dap",
  "sp-database",
  "sp-debug-derive",
@@ -13574,7 +13576,7 @@ dependencies = [
  "staging-xcm-executor",
  "subkey",
  "substrate-bip39",
- "substrate-build-script-utils 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "substrate-build-script-utils 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "substrate-frame-rpc-support",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -13591,7 +13593,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13626,7 +13628,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "doppelganger-consensus",
@@ -13738,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13758,7 +13760,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -15035,7 +15037,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -15133,7 +15135,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15482,7 +15484,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "sp-core",
@@ -15493,7 +15495,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -15525,7 +15527,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "log",
@@ -15548,7 +15550,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15563,7 +15565,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "clap",
@@ -15579,7 +15581,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -15590,7 +15592,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -15601,7 +15603,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -15643,7 +15645,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fnv",
  "futures",
@@ -15669,7 +15671,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15697,7 +15699,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -15720,7 +15722,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15751,7 +15753,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15776,7 +15778,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -15788,7 +15790,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15810,7 +15812,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15844,7 +15846,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15864,7 +15866,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15877,7 +15879,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes",
@@ -15912,7 +15914,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -15922,7 +15924,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -15942,7 +15944,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -15978,7 +15980,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-pow"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -16003,7 +16005,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -16027,7 +16029,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -16050,7 +16052,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -16063,7 +16065,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "polkavm",
@@ -16075,7 +16077,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "anyhow",
  "log",
@@ -16091,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "sc-hop"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "futures-timer",
@@ -16114,7 +16116,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "console",
  "futures",
@@ -16130,7 +16132,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.5",
@@ -16144,7 +16146,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -16172,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16208,7 +16210,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -16223,7 +16225,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -16233,7 +16235,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -16252,7 +16254,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16273,7 +16275,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16297,7 +16299,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16331,7 +16333,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "futures",
@@ -16350,7 +16352,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bs58",
  "bytes",
@@ -16371,7 +16373,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bytes",
  "fnv",
@@ -16405,7 +16407,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16414,7 +16416,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16448,7 +16450,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16469,7 +16471,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -16496,7 +16498,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "cid",
@@ -16531,13 +16533,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -16546,7 +16548,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "directories",
@@ -16610,7 +16612,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16621,7 +16623,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16646,7 +16648,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "fs4",
@@ -16659,7 +16661,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16678,7 +16680,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -16691,14 +16693,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "chrono",
  "futures",
@@ -16717,7 +16719,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "chrono",
  "console",
@@ -16745,7 +16747,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -16756,7 +16758,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -16773,7 +16775,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -16788,7 +16790,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -16806,7 +16808,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16820,7 +16822,7 @@ dependencies = [
 [[package]]
 name = "sc-virtualization"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "polkavm",
@@ -17549,7 +17551,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -17718,7 +17720,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -17739,7 +17741,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -17763,7 +17765,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-inbound-queue-primitives"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "assets-common",
@@ -17789,7 +17791,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-merkle-tree"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17815,7 +17817,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-primitives"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
@@ -17841,7 +17843,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17855,7 +17857,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-v2-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17868,7 +17870,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-primitives",
  "frame-benchmarking",
@@ -17893,7 +17895,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17905,7 +17907,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "frame-benchmarking",
@@ -17931,7 +17933,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17944,7 +17946,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-v2"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "bp-relayers",
@@ -17971,7 +17973,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-v2-fixtures"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17984,7 +17986,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -18007,7 +18009,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue-v2"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-core",
  "bp-relayers",
@@ -18037,7 +18039,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -18058,7 +18060,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system-frontend"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -18079,7 +18081,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system-v2"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -18101,7 +18103,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-common"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -18118,7 +18120,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -18130,7 +18132,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-v2-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -18142,7 +18144,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-verification-primitives"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -18195,7 +18197,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "hash-db",
@@ -18217,7 +18219,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -18231,7 +18233,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18243,7 +18245,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -18257,7 +18259,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18269,7 +18271,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -18280,7 +18282,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -18299,7 +18301,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "futures",
@@ -18316,7 +18318,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18332,7 +18334,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18350,7 +18352,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18358,7 +18360,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -18370,7 +18372,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -18387,7 +18389,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -18398,7 +18400,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18409,7 +18411,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "ark-vrf 0.5.0",
  "array-bytes",
@@ -18440,7 +18442,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -18456,15 +18458,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
 ]
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-crypto-hashing-proc-macro",
 ]
@@ -18472,7 +18474,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "ark-bls12-377 0.5.0",
  "ark-bls12-377-ext",
@@ -18510,7 +18512,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18523,17 +18525,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "sp-dap"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
 ]
@@ -18541,7 +18543,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -18551,7 +18553,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "proc-macro-warning",
  "proc-macro2",
@@ -18562,7 +18564,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -18572,7 +18574,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18584,7 +18586,7 @@ dependencies = [
 [[package]]
 name = "sp-hop"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -18594,7 +18596,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -18607,7 +18609,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bytes",
  "docify",
@@ -18619,7 +18621,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -18633,7 +18635,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -18643,7 +18645,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -18654,7 +18656,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -18663,7 +18665,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -18674,7 +18676,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18685,7 +18687,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18702,7 +18704,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18715,7 +18717,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18725,7 +18727,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "backtrace",
  "regex",
@@ -18734,7 +18736,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18744,7 +18746,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -18775,7 +18777,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18793,7 +18795,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "Inflector",
  "expander",
@@ -18806,7 +18808,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18820,7 +18822,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18833,7 +18835,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hash-db",
  "log",
@@ -18853,7 +18855,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -18868,7 +18870,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -18879,12 +18881,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18896,7 +18898,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18908,7 +18910,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -18920,7 +18922,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18929,7 +18931,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18944,7 +18946,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -18969,7 +18971,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18987,7 +18989,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -18999,7 +19001,7 @@ dependencies = [
 [[package]]
 name = "sp-virtualization"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "log",
  "num_enum",
@@ -19013,7 +19015,7 @@ dependencies = [
 [[package]]
 name = "sp-virtualization-test-fixture"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "polkavm-derive 0.33.0",
  "substrate-wasm-builder",
@@ -19022,7 +19024,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -19034,7 +19036,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "bounded-collections 0.3.2",
  "parity-scale-codec",
@@ -19134,7 +19136,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "1.6.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "docify",
@@ -19147,7 +19149,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -19165,7 +19167,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -19178,12 +19180,12 @@ dependencies = [
 [[package]]
 name = "staging-tracking-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 
 [[package]]
 name = "staging-xcm"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "bounded-collections 0.3.2",
@@ -19204,7 +19206,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "environmental",
  "frame-support",
@@ -19229,7 +19231,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -19344,7 +19346,7 @@ dependencies = [
 [[package]]
 name = "subkey"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "clap",
  "sc-cli",
@@ -19353,7 +19355,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -19384,12 +19386,12 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 
 [[package]]
 name = "substrate-frame-rpc-support"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "jsonrpsee",
@@ -19403,7 +19405,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -19423,7 +19425,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "http-body-util",
  "hyper 1.10.1",
@@ -19437,7 +19439,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -19450,7 +19452,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -19467,7 +19469,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -19838,7 +19840,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "testnet-parachains-constants"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -20250,7 +20252,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20261,7 +20263,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "expander",
  "proc-macro-crate",
@@ -21325,7 +21327,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21428,7 +21430,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -22122,7 +22124,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -22145,7 +22147,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-consensus-aura",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf)",
  "sp-io",
  "sp-runtime",
  "sp-tracing",
@@ -22158,7 +22160,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -22169,7 +22171,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22183,7 +22185,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=7b28a81#7b28a8128a57cae35e60a113bb99204a5be3818b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=e01ff2c0aaf#e01ff2c0aaf6bda83751fc2b53d2fe059324ac77"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doppelganger-wrapper"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [[bin]]
@@ -20,7 +20,7 @@ name = "polkadot-prepare-worker"
 path = "src/prepare-worker.rs"
 
 [dependencies]
-polkadot-sdk = {git = "https://github.com/paritytech/polkadot-sdk.git", features = ["node", "serde", "doppelganger"], rev = "7b28a81" } # branch: doppelganger-bite
+polkadot-sdk = {git = "https://github.com/paritytech/polkadot-sdk.git", features = ["node", "serde", "doppelganger"], rev = "e01ff2c0aaf" } # branch: doppelganger-bite
 #polkadot-sdk = { path = "/Users//parity/polkadot-sdk/umbrella", features = ["node", "serde", "doppelganger"] }
 color-eyre = { version = "0.6.3", default-features = false }
 clap = { version = "4.5.13" }


### PR DESCRIPTION
## Summary

Bumps to `0.2.1`, picking up the host-function fix now on `doppelganger-bite`
(paritytech/polkadot-sdk@e01ff2c0aaf).

`polkadot-sdk` rev `7b28a81` → `e01ff2c0aaf`.

## Why

`DoppelGangerBlockImport::import_block` built its state-version executor with a hand-rolled
host-function tuple that was a strict subset of the node's own set. Any runtime importing something
outside it could not be instantiated, so the bite panicked before producing artifacts.

Concretely, `v0.2.0` cannot bite two of Product Preview Network's five chains at all:

```
[Parachain] Cannot create a runtime error=Other("runtime requires function imports which are not
  present on the host: 'env:ext_host_calls_bls12_381_mul_g1_version_1', … ")
Thread 'tokio-rt-worker' panicked at 'get state_version from storage should works.'
```

Asset Hub needs 5 RFC-163 elliptic-curve host functions; People needs those plus
`ext_statement_store_remove_by_version_1`. The tuple now matches
`polkadot_omni_node_lib::common::types::ParachainHostFunctions`.

Note this is not an SDK-version problem — it reproduced identically on a build rebased onto current
`master`. The shared types already carried these host functions; the copy in doppelganger had drifted.

## Verification

Built from this branch (i.e. from the git rev, not a path override) and run against live previewnet:

| chain | `v0.2.0` | this branch |
| --- | --- | --- |
| relay (paseo-local) | bites | bites |
| bulletin (1501) | bites | bites |
| web3-storage (1600) | bites | bites |
| asset-hub (1500) | **panics** | **bites — block 37751** |
| people (1502) | **panics** | **bites — block 12595** |

All five chains then spawn and finalize, with Asset Hub's 3-core elastic scaling intact.

Two unrelated things found while getting there, for the record — neither is addressed here:

- `:UsePreviousValidators:` silently no-ops on runtimes that lack it (e.g. paseo), so the validator
  set is re-elected at the first session boundary and block production stops after one epoch.
  Worked around with `Staking::ForceEra = ForceNone` in the overrides.
- Since `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` became env-gated upstream, something has to
  set `ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION=1`. Nothing does, and zombienet does not
  forward the parent environment to spawned nodes — so a warp-synced fork never advances its finality
  target past the bite block. GRANDPA votes unanimously; relay chain-selection pins the target because
  the dispute scrape hits ancestry that a warp-synced DB does not have. Probably belongs in
  zombie-bite.
